### PR TITLE
Ignore corrupted cookie file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,6 @@ jobs:
           command: |
             mkdir -p ~/test-reports
             echo "2.3" > .ruby-version
-            gem update --system
             brew untap caskroom/versions
             brew install shellcheck
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
@@ -83,7 +82,6 @@ jobs:
           command: |
             mkdir -p ~/test-reports
             echo "2.5" > .ruby-version
-            gem update --system
             brew untap caskroom/versions
             brew install shellcheck
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
@@ -190,7 +188,6 @@ jobs:
           command: |
             mkdir -p ~/test-reports
             echo "2.5" > .ruby-version
-            gem update --system
             brew untap caskroom/versions
             brew install shellcheck
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -74,7 +74,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('babosa', '>= 1.0.2', "< 2.0.0")
   spec.add_dependency('colored') # colored terminal output
   spec.add_dependency('commander-fastlane', '>= 4.4.6', '< 5.0.0') # CLI parser
-  spec.add_dependency('excon', '>= 0.45.0', '< 1.0.0') # Great HTTP Client
+  spec.add_dependency('excon', '>= 0.71.0', '< 1.0.0') # Great HTTP Client
   spec.add_dependency('faraday-cookie_jar', '~> 0.0.6')
   spec.add_dependency('faraday', '~> 0.17') # Used for deploygate, hockey and testfairy actions
   spec.add_dependency('faraday_middleware', '~> 0.13.1') # same as faraday

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -571,7 +571,7 @@ module Spaceship
         end
       rescue => ex
         puts(ex.to_s)
-        puts("Continuing with other login methods")
+        puts("Continuing with normal login.")
       end
       return false
     end

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -571,7 +571,7 @@ module Spaceship
         end
       rescue => ex
         puts(ex.to_s)
-        puts("Continue with normal login")
+        puts("Continuing with other login methods")
       end
       return false
     end

--- a/spaceship/lib/spaceship/client.rb
+++ b/spaceship/lib/spaceship/client.rb
@@ -563,10 +563,15 @@ module Spaceship
     #####################################################
 
     def load_session_from_file
-      if File.exist?(persistent_cookie_path)
-        puts("Loading session from '#{persistent_cookie_path}'") if Spaceship::Globals.verbose?
-        @cookie.load(persistent_cookie_path)
-        return true
+      begin
+        if File.exist?(persistent_cookie_path)
+          puts("Loading session from '#{persistent_cookie_path}'") if Spaceship::Globals.verbose?
+          @cookie.load(persistent_cookie_path)
+          return true
+        end
+      rescue => ex
+        puts(ex.to_s)
+        puts("Continue with normal login")
       end
       return false
     end


### PR DESCRIPTION
Other than the session in the environment, the session on disk is not provided by the user, so we should not fail if the session cookie is corrupted, instead just fetch a new one.

<!-- Thanks for contributing to _fastlane_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [ ] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [ ] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail. -->
<!-- Please describe in detail how you tested your changes. -->

### Testing Steps
<!-- Optional: steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review by the fastlane team. -->
